### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,67 @@
 setting.py
+
+# Creado por https://www.gitignore.io/api/node
+
+### Node ###
+# Registros
+registros
+*.Iniciar sesión
+npm-debug.log *
+yarn-debug.log *
+yarn-error.log *
+
+# Datos de tiempo de ejecución
+pids
+* .pid
+*.semilla
+* .pid.lock
+
+# Directorio para libs instrumentadas generadas por jscoverage / JSCover
+lib-cov
+
+# Directorio de cobertura utilizado por herramientas como Estambul
+cobertura
+
+# cobertura de prueba nyc
+.nyc_output
+
+# Almacenamiento intermedio Grunt (http://gruntjs.com/creating-plugins#storing-task-files)
+.gruñido
+
+# Directorio de dependencia de Bower (https://bower.io/)
+bower_components
+
+# node-waf configuration
+.lock-wscript
+
+# Complementos binarios compilados (http://nodejs.org/api/addons.html)
+construir / liberar
+
+# Directorios de dependencia
+node_modules /
+jspm_packages /
+
+Archivos de declaración de # Typescript v1
+typings /
+
+# Opcional npm cache directory
+.npm
+
+# Caché eslint opcional
+.eslintcache
+
+# Historial de REPL opcional
+.node_repl_history
+
+# Salida del 'paquete npm'
+* .tgz
+
+# Archivo de integridad del hilo
+.yarn-integrity
+
+# archivo de variables de entorno dotenv
+.env
+
+
+
+# Fin de https://www.gitignore.io/api/node


### PR DESCRIPTION

¿Que ha cambiado?
Agregamos al gitignore soporte para Node js 
- [ ] Frontend
- [ ] Backend
- [x] Configuracion del server

#  ¿Como puedo probar los cambios?
Por ejemplo los archivos y la carpeta node_modules ya no se suben al repo, ver el archivo .gitignore completo
